### PR TITLE
Fix unneeded asset bundle creation

### DIFF
--- a/Assets/ModSDK/SDK/Editor/ModBuilder.cs
+++ b/Assets/ModSDK/SDK/Editor/ModBuilder.cs
@@ -192,9 +192,15 @@ namespace PugMod
 				if (IsInEditorFolder(asset, modDirectory))
 				{
 					continue;
-				}
-				
-				if (!asset.EndsWith(".cs"))
+                }
+
+                if (asset.EndsWith(".asmdef"))
+                {
+                    assetPaths.RemoveAt(i);
+                    continue;
+                }
+
+                if (!asset.EndsWith(".cs"))
 				{
 					continue;
 				}


### PR DESCRIPTION
Filters out .asmdef files so they do not get bundled for no reason.

Makes mods with scripts but no assets to bundle build almost instantly as it no longer makes 2 junk asset bundles that nothing uses.