### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This is the official Mod SDK for Core Keeper! Use it to create and publish amazi
 
 ## Requirements
 [Unity Editor 2022.3.50f1](https://unity.com/releases/editor/whats-new/2022.3.50)
+> [!NOTE]
+> It is recommended to install the editor via [Unity Hub](https://unity.com/download#how-to-get-started).
 
 ## How to run
 


### PR DESCRIPTION
Myself and some other community members who installed the Unity Editor outside of the Hub faced some issues like not having the option to build for Linux.  

To avoid this, I added a small note about installing the Unity Editor via the Hub so the necessary modules can be explicitly selected.

