### PR TITLE
Fix Steam Workshop settings being keyed on the title instead of the mod name

### DIFF
--- a/Packages/dev.pugstorm.mod/SDK/Editor/ModSDKWindow/SteamWorkshopTab.cs
+++ b/Packages/dev.pugstorm.mod/SDK/Editor/ModSDKWindow/SteamWorkshopTab.cs
@@ -366,7 +366,9 @@ namespace PugMod
 				var steamWorkshopModSettings = _steamWorkshopModSettings.FirstOrDefault(x => x.modName == modName);
 
 				_steamWorkshopFileID.value = Convert.ToString(steamWorkshopModSettings.fileId);
-				_steamWorkshopFolderName.value = steamWorkshopModSettings.modName;
+				// Settings with no recorded title keep it in modName.
+				var title = steamWorkshopModSettings.title;
+				_steamWorkshopFolderName.value = string.IsNullOrEmpty(title) ? steamWorkshopModSettings.modName : title;
 				_selectedWorkshopPath = steamWorkshopModSettings.selectedPath;
 				_steamWorkshopTagsToList.Clear();
 				_steamWorkshopTagsToList.AddRange(steamWorkshopModSettings.tags);
@@ -452,7 +454,7 @@ namespace PugMod
 					if (result.Success)
 					{
 						EditorUtility.DisplayDialog("the mod was uploaded via steam workshop!", $"published file ID: {result.FileId}.", "OK.");//could add more info here next to the published file ID
-						SaveSteamWorkshopSettings(result.FileId, _steamWorkshopFolderName.value, _selectedWorkshopPath, _steamWorkshopTagsToList);
+						SaveSteamWorkshopSettings(result.FileId, _steamModList.value, _steamWorkshopFolderName.value, _selectedWorkshopPath, _steamWorkshopTagsToList);
 						_steamWorkshopFileID.value = Convert.ToString(result.FileId);
 						RefreshSteamWorkshopUploadButton();
 					}
@@ -525,7 +527,7 @@ namespace PugMod
 					if (result.Success)
 					{
 						EditorUtility.DisplayDialog("the mod was updated successfully", $"updated file id: {result.FileId}.", "OK.");//could add more info here next to the published file ID
-						SaveSteamWorkshopSettings(result.FileId, _steamWorkshopFolderName.value, _selectedWorkshopPath, _steamWorkshopTagsToList);
+						SaveSteamWorkshopSettings(result.FileId, _steamModList.value, _steamWorkshopFolderName.value, _selectedWorkshopPath, _steamWorkshopTagsToList);
 					}
 					else
 					{
@@ -537,10 +539,27 @@ namespace PugMod
 					ShowError($"an error occurred: {ex.Message}");
 				}
 			}
-			private void SaveSteamWorkshopSettings(ulong FileID, string ModName, string SelectedPath, List<string> Tags)
+			private void SaveSteamWorkshopSettings(ulong FileID, string ModName, string Title, string SelectedPath, List<string> Tags)
 			{
 				SteamWorkshopModSettings steamSettings;
 				var existingSettings = _steamWorkshopModSettings.FirstOrDefault(x => x.fileId == FileID);
+
+				// The mod dropdown reads null when its selection is out of step with the
+				// stored mod preference, and when no mod exists at all. Saving that name
+				// would leave the settings unreachable by either lookup, so take it from the
+				// asset this file id already belongs to. Settings that still keep their title
+				// in modName are left alone: adopting that title as the name would cost them
+				// the empty title that identifies them as predating this field.
+				if (string.IsNullOrEmpty(ModName) && existingSettings != null && !string.IsNullOrEmpty(existingSettings.title))
+				{
+					ModName = existingSettings.modName;
+				}
+
+				if (string.IsNullOrEmpty(ModName))
+				{
+					ShowError($"No mod is selected, so the Workshop settings were not saved. The published file id is {FileID}. Pick the mod in the dropdown, put that id in the File ID field, and upload again to store it.");
+					return;
+				}
 
 				if (_steamWorkshopModSettings == null)
 				{
@@ -558,6 +577,7 @@ namespace PugMod
 				steamSettings.fileId = FileID;
 				steamSettings.tags = new List<string>(Tags);
 				steamSettings.modName = ModName;
+				steamSettings.title = Title;
 				steamSettings.selectedPath = _selectedWorkshopPath;
 				steamSettings.modOwner = SteamApps.AppOwner.ToString();
 				//steamSettings.Change(SteamApps.AppOwner.ToString()); if we want to serialize modOnwer ID but don't want it visible in inspector, uncomment Change method first in SteamWorkshopSettings.cs

--- a/Packages/dev.pugstorm.mod/SDK/Editor/ModSDKWindow/SteamWorkshopTab.cs
+++ b/Packages/dev.pugstorm.mod/SDK/Editor/ModSDKWindow/SteamWorkshopTab.cs
@@ -187,11 +187,12 @@ namespace PugMod
 				.Select(guid => AssetDatabase.GUIDToAssetPath(guid))
 				.Select(path => AssetDatabase.LoadAssetAtPath<SteamWorkshopModSettings>(path)));
 
-				var steamWorkshopModSettings = _steamWorkshopModSettings.FirstOrDefault(x => x.modName == modName);
+				var settingsByName = _steamWorkshopModSettings.FirstOrDefault(x => x.modName == modName);
+				var steamWorkshopModSettings = settingsByName != null ? settingsByName : FindLegacySettingsByPath(modName);
 
 				if (steamWorkshopModSettings != null)
 				{
-					SelectSteamWorkshopModSettings(modName);
+					SelectSteamWorkshopModSettings(steamWorkshopModSettings);
 				}
 				else
 				{
@@ -361,10 +362,43 @@ namespace PugMod
 				}
 			}
 
-			private void SelectSteamWorkshopModSettings(string modName)
+			// Recovers settings written before the title field existed, whose modName
+			// holds the Workshop title: their selectedPath still ends in the mod's
+			// internal name, and the next upload rewrites modName and title. Comparing
+			// the last path segment avoids matching a mod whose name is merely a suffix
+			// of the stored folder name. UpdateSelectedWorkshopPath still selects that
+			// path with EndsWith, so such a pair can already have the wrong path stored.
+			private SteamWorkshopModSettings FindLegacySettingsByPath(string modName)
 			{
-				var steamWorkshopModSettings = _steamWorkshopModSettings.FirstOrDefault(x => x.modName == modName);
+				// Steam file ids grow over time, so of several candidates the newest is the
+				// better guess, and ordering makes the choice reproducible where the asset
+				// database's own order is not.
+				var candidates = _steamWorkshopModSettings.Where(x =>
+					string.IsNullOrEmpty(x.title) &&
+					!string.IsNullOrEmpty(x.selectedPath) &&
+					x.selectedPath.Split('/', '\\').Last() == modName).OrderByDescending(x => x.fileId).ToList();
 
+				if (candidates.Count == 0)
+				{
+					return null;
+				}
+
+				// A mod that hit this bug can own more than one settings asset, because every
+				// upload that lost its file id created another Workshop item.
+				if (candidates.Count > 1)
+				{
+					Debug.LogWarning($"Found {candidates.Count} Workshop settings without a title for '{modName}'. Using file id {candidates[0].fileId} ({AssetDatabase.GetAssetPath(candidates[0])}), ignoring {string.Join(", ", candidates.Skip(1).Select(x => x.fileId))}. Check the File ID before uploading.");
+				}
+				else
+				{
+					Debug.Log($"Recovered Workshop settings for '{modName}' from {AssetDatabase.GetAssetPath(candidates[0])}.");
+				}
+
+				return candidates[0];
+			}
+
+			private void SelectSteamWorkshopModSettings(SteamWorkshopModSettings steamWorkshopModSettings)
+			{
 				_steamWorkshopFileID.value = Convert.ToString(steamWorkshopModSettings.fileId);
 				// Settings with no recorded title keep it in modName.
 				var title = steamWorkshopModSettings.title;
@@ -549,7 +583,7 @@ namespace PugMod
 				// would leave the settings unreachable by either lookup, so take it from the
 				// asset this file id already belongs to. Settings that still keep their title
 				// in modName are left alone: adopting that title as the name would cost them
-				// the empty title that identifies them as predating this field.
+				// the empty title that the recovery above identifies them by.
 				if (string.IsNullOrEmpty(ModName) && existingSettings != null && !string.IsNullOrEmpty(existingSettings.title))
 				{
 					ModName = existingSettings.modName;

--- a/Packages/dev.pugstorm.mod/SDK/Editor/SteamWorkshopModSettings.cs
+++ b/Packages/dev.pugstorm.mod/SDK/Editor/SteamWorkshopModSettings.cs
@@ -14,7 +14,12 @@ namespace PugMod
 		[ReadOnly][SerializeField] public string modOwner;
 		public string _modOwner => modOwner;
 
+		// The mod's internal name, matching ModMetadata.name. The Steam Workshop tab
+		// looks up settings by this field, so it must not hold a display title.
 		public string modName;
+		// The Workshop title, which may differ from modName. Empty in settings
+		// written before this field existed.
+		public string title;
 		public string selectedPath;
 		public List<string> tags = new();
 

--- a/Packages/dev.pugstorm.mod/SDK/Editor/SteamWorkshopModSettings.cs
+++ b/Packages/dev.pugstorm.mod/SDK/Editor/SteamWorkshopModSettings.cs
@@ -17,8 +17,8 @@ namespace PugMod
 		// The mod's internal name, matching ModMetadata.name. The Steam Workshop tab
 		// looks up settings by this field, so it must not hold a display title.
 		public string modName;
-		// The Workshop title, which may differ from modName. Empty in settings
-		// written before this field existed.
+		// The Workshop title, which may differ from modName. Empty in settings written
+		// before this field existed, which is how the tab recognises and repairs them.
 		public string title;
 		public string selectedPath;
 		public List<string> tags = new();


### PR DESCRIPTION
Fixes #11.

`SteamWorkshopModSettings.modName` is written from the Title field but looked up by `ModMetadata.name`. As soon as a mod is uploaded with a title that differs from its internal name, the Steam Workshop tab stops finding the asset it wrote itself — the File ID field and the tag list come back empty and the Title field resets to the internal name. Since an empty File ID sends the next upload down the `NewCommunityFile` branch, the following upload creates a second Workshop item instead of updating the first.

The asymmetry is not a recent regression; it is present in the tab's first version (`2ba4031`).

## What the two commits do

**1. Key the settings on the mod name, not the title.** A new `title` field holds what the Title field shows, `modName` always holds the internal name and stays the lookup key. Reading falls back to `modName` when no title has been saved, so settings written by earlier versions keep their title and nothing changes for the common case where the two were always equal.

The internal name now comes from the mod dropdown, and that reads `null` when its selection is out of step with `CHOSEN_MOD_KEY` (`Refresh()` sets the index without the `-1` guard `OnEnable` has) or when no mod exists at all. An empty `modName` would leave the settings unreachable by either lookup, so it is recovered from the asset the file id already belongs to, and saving is refused outright when even that is missing — with the published file id in the message, since the success dialog has been dismissed by then.

**2. Recover settings written before the split.** Those hold the title in `modName` and so no longer match their mod. Their `selectedPath` still ends in the internal name, which is enough to find them again; the next upload then rewrites both fields, because it locates the asset by `fileId`. Nothing is rewritten on load.

A mod that hit this bug often owns *several* such assets — every upload that lost its File ID created another Workshop item and another asset beside it. Picking one silently would bind the wrong item to the mod, so candidates are ordered by file id and an ambiguous match is logged with the ids not taken.

The second commit is separable: the first fixes the bug for everyone from here on, the second is what makes it right for projects that already have broken settings assets.

## Verification

Compiles clean: a fresh clone of this branch built in batch mode on Unity 6000.0.59f2 with no compiler errors, and the added code is present in the resulting `ModSDK.Editor` assembly. I have **not** run a real Workshop upload against it, so the upload paths below are unverified by me.

Most of it can be checked without touching Steam, by editing the `.asset` YAML by hand:

| Case | Setup | Expected |
|---|---|---|
| Existing asset, title always equalled the internal name (**the common case**) | `modName` = internal name, no `title`, `fileId` ≥ 9 digits | Primary lookup as before — File ID kept, button says *Update*, Title field shows the internal name, not blank |
| Existing asset in the broken state | `modName` = the title, no `title`, `selectedPath` ending in the internal name | Recovery hits — File ID filled, button says *Update*, Title field shows the title |
| Two mods, one name a suffix of the other | One asset each, distinct `fileId` | Each shows its own File ID |
| Broken asset whose `selectedPath` is empty or stale | as above | Recovery does **not** hit — a deliberate limit, see below |

Needs a real upload (Visibility *Private*, item deleted afterwards): that a first upload writes both fields and lands the asset under `Assets/<internal name>/`; that a recovered asset keeps its File ID and creates no duplicate.

## Deliberately not included

Three pre-existing things this touches without fixing, so they are not mistaken for part of it:

- `UpdateSelectedWorkshopPath` still resolves the build path with `EndsWith(modName)`, which can pick `…/SuperMod` for the mod `Mod`. The recovery compares the last path segment instead, so it will not claim another mod's settings — but a wrong path may already be stored from before. Fixing the resolution itself is a separate change.
- `Refresh()` lacks the `-1` guard that `OnEnable` has, so `UpdateSelectedWorkshopPath(null)` can throw `ArgumentNullException` there. The guard added here catches the consequence for the settings asset, not the cause.
- `SaveSteamWorkshopSettings` never reads its `SelectedPath` parameter — it uses the field. This PR adds a parameter next to it rather than changing that.

I have read and agree to the [EULA](EULA.txt).
